### PR TITLE
Add test suite, unextend function, various tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/unplgtc/CBLogger.svg?style=svg)](https://circleci.com/gh/unplgtc/CBLogger)
+
 # CBLogger
 
 Standardized logging object for Node applications

--- a/src/CBLogger.js
+++ b/src/CBLogger.js
@@ -1,23 +1,23 @@
 'use strict';
 
-const StandardError = require('@unplgtc/StandardError');
+const StandardError = require('@unplgtc/standarderror');
 const path = require('path');
 const util = require('util');
 
 const CBLogger = {
-	debug(key, data, options = {}, err) {
+	debug(key, data, options, err) {
 		this.log('DEBUG', key, data, options, err);
 	},
 
-	info(key, data, options = {}, err) {
+	info(key, data, options, err) {
 		this.log('INFO', key, data, options, err);
 	},
 
-	warn(key, data, options = {}, err) {
+	warn(key, data, options, err) {
 		this.log('WARN', key, data, options, err);
 	},
 
-	error(key, data, options = {}, err) {
+	error(key, data, options, err) {
 		this.log('ERROR', key, data, options, err);
 	},
 
@@ -26,11 +26,21 @@ const CBLogger = {
 			return StandardError.cblogger_409;
 		}
 		return this.extendPrototype(object);		
+	},
+
+	unextend() {
+		if (!this._extended) {
+			return StandardError.cblogger_405;
+		}
+		return this.unextendPrototype();
 	}
 }
 
 const Internal = {
 	log(level, key, data, options, err) {
+		if (!options || typeof options != 'object') {
+			options = {};
+		}
 		var sourceStack = this.sourceStack();
 		var ts = new Date();
 		var output = [
@@ -40,7 +50,7 @@ const Internal = {
 			`\n-> ${sourceStack.source}`,
 			`${options.ts !== 'false' ? `at ${ts.toISOString().replace('T', ' ')} (${ts.getTime()})` : ''}`,
 			`${options.stack ? `\n   ${sourceStack.stack}` : ''}`
-		];
+		].filter(line => line);
 		if (['WARN', 'ERROR'].includes(level)) {
 			console.error(...output);
 		} else {
@@ -58,7 +68,8 @@ const Internal = {
 	sourceStack() {
 		// Pull the stack trace and cut CBLogger lines out of it
 		var stack = (new Error().stack).split('\n').slice(4);
-		return {source: path.basename(stack[0]).split(':')[0], stack: stack.join('\n').slice(4)};
+		var source = path.basename(stack[0]).split(':');
+		return {source: `${source[0]} L${source[1]}`, stack: stack.join('\n').slice(4)};
 	},
 
 	extendPrototype(object) {
@@ -69,10 +80,18 @@ const Internal = {
 		// Delegate from Internal to extended object
 		Object.setPrototypeOf(Object.getPrototypeOf(this), object);
 		return true;
+	},
+
+	unextendPrototype() {
+		this._extended = false;
+		// Delegate from Internal to extended object
+		Object.setPrototypeOf(Object.getPrototypeOf(this), Object.prototype);
+		return true;
 	}
 }
 
 StandardError.add([
+	{code: 'cblogger_405', domain: 'CBLogger', title: 'Method Not Allowed', message: 'Cannot unextend because CBLogger is not currently extended'},
 	{code: 'cblogger_409', domain: 'CBLogger', title: 'Conflict', message: 'Logger has already been extended'},
 	{code: 'cblogger_501', domain: 'CBLogger', title: 'Not Implemented', message: 'Alert object passed to `CBLogger.extend` does not implement an `alert` function'},
 	{code: 'cblogger_503', domain: 'CBLogger', title: 'Service Unavailable', message: 'CBLogger has not been extended, alert service unavailable'}

--- a/test/CBLogger.test.js
+++ b/test/CBLogger.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const CBLogger = require('./../src/CBLogger');
+const StandardError = require('@unplgtc/standarderror');
+const util = require('util');
+
+// Global Setup
+var alerter = {
+	alert(key, scope) {
+		console.log(`ALERTING ${key} with scope ${scope}`)
+	}
+}
+
+// Tests
+test(`Extend CBLogger with alerter object`, async() => {
+	// Setup
+	var badAlerter = {
+		functionNotNamedAlert(nope) {
+			console.error(nope);
+		}
+	}
+
+	// Execute
+	var badRes = CBLogger.extend(badAlerter);
+	var goodRes = CBLogger.extend(alerter);
+
+	// Test
+	expect(badRes).toBe(StandardError.cblogger_501);
+	expect(goodRes).toBe(true);
+});
+
+test(`Unextend CBLogger`, async() => {
+	// Execute
+	var res = CBLogger.unextend();
+	var errRes = CBLogger.unextend();
+
+	// Test
+	expect(res).toBe(true);
+	expect(errRes).toBe(StandardError.cblogger_405);
+});
+
+describe.each`
+	key                    | data                  | options          | err                   | logFunc    | func
+	${'debug_1_simple'}    | ${{text: 'Test 1'}}   | ${undefined}     | ${undefined}          | ${'log'}   | ${'debug'}
+	${'debug_2_err'}       | ${{text: 'Test 2'}}   | ${undefined}     | ${StandardError[500]} | ${'log'}   | ${'debug'}
+	${'debug_3_stack'}     | ${{text: 'Test 3'}}   | ${{stack: true}} | ${StandardError[500]} | ${'log'}   | ${'debug'}
+	${'debug_4_no_ts'}     | ${{text: 'Test 4'}}   | ${{ts: false}}   | ${StandardError[500]} | ${'log'}   | ${'debug'}
+	${'info_1_simple'}     | ${{text: 'Test 5'}}   | ${undefined}     | ${undefined}          | ${'log'}   | ${'info'}
+	${'info_2_no_data'}    | ${undefined}          | ${undefined}     | ${undefined}          | ${'log'}   | ${'info'}
+	${'info_3_nulls'}      | ${null}               | ${null}          | ${null}               | ${'log'}   | ${'info'}
+	${'warn_1_simple'}     | ${{text: 'Test 8'}}   | ${undefined}     | ${undefined}          | ${'error'} | ${'warn'}
+	${'warn_2_err'}        | ${{text: 'Test 9'}}   | ${undefined}     | ${StandardError[500]} | ${'error'} | ${'warn'}
+	${'warn_3_big_data'}   | ${{t:'e',s:'t',n:10}} | ${undefined}     | ${StandardError[500]} | ${'error'} | ${'warn'}
+	${'error_1_simple'}    | ${{text: 'Test 11'}}  | ${undefined}     | ${undefined}          | ${'error'} | ${'error'}
+	${'error_2_err_txt'}   | ${{text: 'Test 12'}}  | ${undefined}     | ${'Error!'}           | ${'error'} | ${'error'}
+	${'error_3_err_obj'}   | ${{text: 'Test 13'}}  | ${undefined}     | ${StandardError[500]} | ${'error'} | ${'error'}
+	${'error_4_err_stack'} | ${{text: 'Test 14'}}  | ${{stack: true}} | ${StandardError[500]} | ${'error'} | ${'error'}
+`(`CBLogger logs expected output for each logging function based on arguments`, ({key, data, options, err, logFunc, func}) => {
+	// Setup
+	console.log = jest.fn();
+	console.error = jest.fn();
+	CBLogger.sourceStack = jest.fn(() => mockedSourceStack);
+	var mockedDate = new Date();
+	global.Date = jest.fn(() => mockedDate);
+	var mockedOpts = options;
+	if (!mockedOpts || typeof mockedOpts != 'object') {
+		mockedOpts = {};
+	}
+	var mockedSource = 'fileName L1';
+	var mockedStack = new Error().stack;
+	var mockedSourceStack = {source: mockedSource, stack: mockedStack};
+	var keyLine = `${func.toUpperCase()}: ** ${key}`;
+	var dataLine = `${data ? `\n${util.inspect(data)}` : ''}`;
+	var errLine = `${err ? `\n** ${(typeof err == 'string' ? err : util.inspect(err))}` : ''}`;
+	var sourceLine = `\n-> ${mockedSource}`;
+	var tsLine = `${mockedOpts.ts !== 'false' ? `at ${mockedDate.toISOString().replace('T', ' ')} (${mockedDate.getTime()})` : ''}`;
+	var stackLine = `${mockedOpts.stack ? `\n   ${mockedStack}` : ''}`;
+
+	var args = [key, data, options, err];
+	var outputArgs = [keyLine, dataLine, errLine, sourceLine, tsLine, stackLine].filter(arg => arg);
+
+	// Test Cases
+	test(`${key}`, async() => {
+		// Execute
+		CBLogger[func](...args);
+
+		// Test
+		expect(console[logFunc]).toHaveBeenCalledWith(...outputArgs);
+	});
+
+	test(`${key} with alert, sans alerter outputs expected log message + alert error`, async() => {
+		// Setup
+		if (!options || typeof options != 'object') {
+			options = {};
+		}
+		options.alert = true;
+		options.scope = func;
+		args = [key, data, options, err];
+		var errorKeyLine = `ERROR: ** logger_cannot_alert`;
+		var errorStackLine = `\n   ${mockedStack}`;
+		var errorErrLine = `\n** ${util.inspect(StandardError.cblogger_503)}`;
+
+		// Execute
+		CBLogger[func](...args);
+
+		// Test
+		expect(console[logFunc]).toHaveBeenCalledWith(...outputArgs);
+		expect(console.error).toHaveBeenCalledWith(errorKeyLine, errorErrLine, sourceLine, tsLine, errorStackLine);
+	});
+
+	test(`add alerter`, async() => {
+		// Execute
+		var res = CBLogger.extend(alerter);
+
+		// Test
+		expect(res).toBe(true);
+	});
+
+	test(`${key} with alert and alerter outputs expected log message + fires alerter`, async() => {
+		// Setup
+		var alertMessage = `ALERTING ${key} with scope ${func}`;
+
+		// Execute
+		CBLogger[func](...args);
+
+		// Test
+		expect(console[logFunc]).toHaveBeenCalledWith(...outputArgs);
+		expect(console.log).toHaveBeenCalledWith(alertMessage);
+	});
+
+	test(`remove alerter`, async() => {
+		// Execute
+		var res = CBLogger.unextend();
+
+		// Test
+		expect(res).toBe(true);
+	});	
+});


### PR DESCRIPTION
- Build out full Jest test suite for CBLogger project
- Add CircleCI pass/fail badge to README
- Remove default parameter override for `options` param because it doesn't work for `null` being passed in
  - Instead defaulting of that param is now applied within the `log` function in a way that will override any non-object value
- Add ability to unextend CBLogger after it has been extended
  - This is mainly to make cleanup easy during test cases but it seemed arbitrary to not allow users to access the functionality
- Added line number as part of the source output line