### PR TITLE
Updated required alerter interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "homepage": "https://github.com/unplgtc/CBLogger#readme",
   "devDependencies": {
-    "jest": "^23.4.2"
+    "jest": "^23.4.2",
+    "@unplgtc/cbalerter": "0.0.1"
   },
   "dependencies": {
     "@unplgtc/standarderror": "0.0.1"

--- a/src/CBLogger.js
+++ b/src/CBLogger.js
@@ -23,14 +23,14 @@ const CBLogger = {
 
 	extend(object) {
 		if (this._extended) {
-			return StandardError.cblogger_409;
+			return StandardError.CBLogger_409;
 		}
 		return this.extendPrototype(object);		
 	},
 
 	unextend() {
 		if (!this._extended) {
-			return StandardError.cblogger_405;
+			return StandardError.CBLogger_405;
 		}
 		return this.unextendPrototype();
 	}
@@ -58,9 +58,9 @@ const Internal = {
 		}
 		if (options.alert) {
 			if (this._extended) {
-				this.alert(key, options.scope);
+				this.alert(level, key, data, options, err);
 			} else {
-				this.error('logger_cannot_alert', null, {stack: true}, StandardError.cblogger_503);
+				this.error('logger_cannot_alert', null, {stack: true}, StandardError.CBLogger_503);
 			}
 		}
 	},
@@ -74,7 +74,7 @@ const Internal = {
 
 	extendPrototype(object) {
 		if (!object.hasOwnProperty('alert') || typeof object.alert != 'function') {
-			return StandardError.cblogger_501;
+			return StandardError.CBLogger_501;
 		}
 		this._extended = true;
 		// Delegate from Internal to extended object
@@ -91,10 +91,10 @@ const Internal = {
 }
 
 StandardError.add([
-	{code: 'cblogger_405', domain: 'CBLogger', title: 'Method Not Allowed', message: 'Cannot unextend because CBLogger is not currently extended'},
-	{code: 'cblogger_409', domain: 'CBLogger', title: 'Conflict', message: 'Logger has already been extended'},
-	{code: 'cblogger_501', domain: 'CBLogger', title: 'Not Implemented', message: 'Alert object passed to `CBLogger.extend` does not implement an `alert` function'},
-	{code: 'cblogger_503', domain: 'CBLogger', title: 'Service Unavailable', message: 'CBLogger has not been extended, alert service unavailable'}
+	{code: 'CBLogger_405', domain: 'CBLogger', title: 'Method Not Allowed', message: 'Cannot unextend because CBLogger is not currently extended'},
+	{code: 'CBLogger_409', domain: 'CBLogger', title: 'Conflict', message: 'Logger has already been extended'},
+	{code: 'CBLogger_501', domain: 'CBLogger', title: 'Not Implemented', message: 'Alert object passed to `CBLogger.extend` does not implement an `alert` function'},
+	{code: 'CBLogger_503', domain: 'CBLogger', title: 'Service Unavailable', message: 'CBLogger has not been extended, alert service unavailable'}
 ]);
 
 Object.setPrototypeOf(CBLogger, Internal);

--- a/test/CBLogger.integration.test.js
+++ b/test/CBLogger.integration.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const CBLogger = require('./../src/CBLogger');
+const CBAlerter = require('@unplgtc/cbalerter');
+const util = require('util');
+
+test(`Extend CBLogger with CBAlerter and fire alert`, async() => {
+	// Setup
+	var mockedSource = 'fileName L1';
+	var mockedStack = new Error().stack;
+	var mockedSourceStack = {source: mockedSource, stack: mockedStack};
+
+	CBAlerter.alert = jest.fn();
+	console.log = jest.fn();
+	CBLogger.sourceStack = jest.fn(() => mockedSourceStack);
+
+	var mockedDate = new Date();
+	global.Date = jest.fn(() => mockedDate);
+
+	var args = ['cbalerter_test', {text: 'Testing CBAlerter'}, {alert: true}];
+	var keyLine = `DEBUG: ** ${args[0]}`;
+	var dataLine = `${`\n${util.inspect(args[1])}`}`;
+	var sourceLine = `\n-> ${mockedSource}`;
+	var tsLine = `at ${mockedDate.toISOString().replace('T', ' ')} (${mockedDate.getTime()})`;
+
+	CBAlerter.addWebhook(function(level, key, data, options, err) {
+		return {
+			url: 'test_url',
+			body: {
+				key: key,
+				data: data
+			},
+			json: true
+		};
+	});
+
+	// Execute
+	var res = CBLogger.extend(CBAlerter);
+	CBLogger.debug(...args);
+
+	// Test
+	expect(res).toBe(true);
+	expect(console.log).toHaveBeenCalledWith(keyLine, dataLine, sourceLine, tsLine);
+	expect(CBAlerter.alert).toHaveBeenCalledWith('DEBUG', ...args, undefined);
+});


### PR DESCRIPTION
- Alerter must now accept the same arguments as CBLogger and output a function which should in turn output a payload to be posted to the alert webhook
- Split tests out into unit and integration and added CBAlerter to the integration tests
- Various tweaks and fixes, including changing the custom StandardError errors to be capitalized like the filename