### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cblogger",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Quality logger for Node applications",
   "main": "src/CBLogger.js",
   "scripts": {


### PR DESCRIPTION
Changelog:
- Add Honeybadger error reporting support
- Changed interface to `CBLogger.extend()` to require an `EXTENSION` enum value of either `CBLogger.EXTENSION.Alerter` or `CBLogger.EXTENSION.Honeybadger`