### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unplgtc/cblogger",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Quality logger for Node applications",
   "type": "module",
   "exports": "./src/CBLogger.js",


### PR DESCRIPTION
Changelog:
- Upgrade to use ES Modules
- Drop support for CommonJS imports
- Upgrade to use StandardError v3
- Add support for `depth` option to set output depth for `data` objects